### PR TITLE
Fix hh_search_dbs option in parallel mode and blastp outfmt in non-parallel mode

### DIFF
--- a/virannot.py
+++ b/virannot.py
@@ -336,7 +336,6 @@ for newfile in sorted(glob.glob("CONTIG_*.fna")):
 					commandsB.write(line2writeB)
 					print "Creating file to run parallel HHpred: adding %s using default parameters." % singleprot
 					lineC = ['hhsearch', '-i', hhtempout, '-d', '{!r}'.format(hh_search_dbs), '-o', hhout, '-v', "0", '\n']
-					print('lineC', lineC)
 					line2writeC = ' '.join(lineC)
 					commandsC.write(line2writeC)
 

--- a/virannot.py
+++ b/virannot.py
@@ -110,7 +110,7 @@ root_output = args.rootoutput
 if not root_output:
     root_output = '{}_annotated'.format(os.path.splitext(args.inputfile)[0])
 
-hh_search_dbs = '{!r}'.format(' '.join(args.hhsearchdatabase))
+hh_search_dbs = '{}'.format(' '.join(args.hhsearchdatabase))
 
 # Printing the header of the program 
 print "This is VirAnnot ", version
@@ -245,10 +245,10 @@ for newfile in sorted(glob.glob("CONTIG_*.fna")):
 	if args.noparallel==True:
 		if args.blastexh==True:
 			print "Running BLAST to predict the genes according to homology inference in %s using exhaustive mode (see Fozo et al. (2010) Nucleic Acids Res for details)" % newfile
-			subprocess.call(['blastp', '-query', "temp.faa", '-db', args.blastdatabase, '-evalue', str(args.blastevalue), '-outfmt', '"6 qseqid sseqid pident length qlen slen qstart qend evalue bitscore stitle', '-out', 'temp_blast.csv', '-max_target_seqs', '10', '-word_size', '2', '-gapopen', '8', '-gapextend', '2', '-matrix', '"PAM70"', '-comp_based_stats', '"0"', "-num_threads", str(args.ncpus)])
+			subprocess.call(['blastp', '-query', "temp.faa", '-db', args.blastdatabase, '-evalue', str(args.blastevalue), '-outfmt', '6 qseqid sseqid pident length qlen slen qstart qend evalue bitscore stitle', '-out', 'temp_blast.csv', '-max_target_seqs', '10', '-word_size', '2', '-gapopen', '8', '-gapextend', '2', '-matrix', '"PAM70"', '-comp_based_stats', '"0"', "-num_threads", str(args.ncpus)])
 		else:
 			print "Running BLAST to predict the genes according to homology inference in %s using default parameters" % newfile
-			subprocess.call(['blastp', '-query', "temp.faa", '-db', args.blastdatabase, '-evalue', str(args.blastevalue), '-outfmt', '"6 qseqid sseqid pident length qlen slen qstart qend evalue bitscore stitle"', '-out', 'temp_blast.csv', '-max_target_seqs', '10', "-num_threads", str(args.ncpus)])
+			subprocess.call(['blastp', '-query', "temp.faa", '-db', args.blastdatabase, '-evalue', str(args.blastevalue), '-outfmt', '6 qseqid sseqid pident length qlen slen qstart qend evalue bitscore stitle', '-out', 'temp_blast.csv', '-max_target_seqs', '10', "-num_threads", str(args.ncpus)])
 	else:
 		with open("commands.sh", "w") as commands:
 			for j in sorted(glob.glob("SEQ_*.faa")):
@@ -326,7 +326,7 @@ for newfile in sorted(glob.glob("CONTIG_*.fna")):
 					line2writeB = ' '.join(lineB)
 					commandsB.write(line2writeB)
 					print "Creating file to run parallel HHpred: adding %s using exhaustive mode (see Fidler et al. (2016) Traffic for details)." % singleprot
-					lineC = ['hhsearch', '-i', hhtempout, '-d', hh_search_dbs, '-o', hhout, '-mac', '-e', '0.01', '-v', "0", '\n']
+					lineC = ['hhsearch', '-i', hhtempout, '-d', '{!r}'.format(hh_search_dbs), '-o', hhout, '-mac', '-e', '0.01', '-v', "0", '\n']
 					line2writeC = ' '.join(lineC)
 					commandsC.write(line2writeC)
 				else:
@@ -335,7 +335,8 @@ for newfile in sorted(glob.glob("CONTIG_*.fna")):
 					line2writeB = ' '.join(lineB)
 					commandsB.write(line2writeB)
 					print "Creating file to run parallel HHpred: adding %s using default parameters." % singleprot
-					lineC = ['hhsearch', '-i', hhtempout, '-d', hh_search_dbs, '-o', hhout, '-v', "0", '\n']
+					lineC = ['hhsearch', '-i', hhtempout, '-d', '{!r}'.format(hh_search_dbs), '-o', hhout, '-v', "0", '\n']
+					print('lineC', lineC)
 					line2writeC = ' '.join(lineC)
 					commandsC.write(line2writeC)
 


### PR DESCRIPTION
This PR fixes the command line format of hh search databases in parallel mode and blastp
    output format (outfmt) in non-parallel mode so results from both modes are the same.